### PR TITLE
add action to update downstream repos

### DIFF
--- a/.github/workflows/update_downstream_repos.yml
+++ b/.github/workflows/update_downstream_repos.yml
@@ -1,0 +1,41 @@
+name: Update downstream repositories
+
+on:
+  push:
+    branches:
+      - main
+
+env:
+  BUILD_TYPE: Release
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    permissions:
+      actions: write
+
+    steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.11.0
+        with:
+          access_token: ${{ github.token }}
+
+      - name: Checkout acquire-video-runtime
+        uses: actions/checkout@v3
+        with:
+          repository: 'acquire-video-runtime'
+          submodules: true
+
+      - name: Update the acquire-core-libs and acquire-driver-common submodules
+        run: |
+          pushd src/acquire-core-libs
+          git checkout main
+          popd
+          pushd tests/acquire-driver-common
+          git checkout ${{ github.sha }}
+          popd
+          git add src/acquire-core-libs tests/acquire-driver-common
+          git commit -m "(automated) update acquire-core-libs and acquire-driver-common"
+          git push
+        working-directory: ${{github.workspace}}/acquire-video-runtime


### PR DESCRIPTION
Updates acquire-video-runtime, which will trigger updates to acquire-driver-hdcam and acquire-driver-zarr, which will trigger an update to acquire-driver-egrabber.