### PR TITLE
add option for linking against the dll version of the msvc runtime

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@ include(cmake/aq_require.cmake)
 include(cmake/git-versioning.cmake)
 include(cmake/ide.cmake)
 include(cmake/install-prefix.cmake)
+include(cmake/msvc.cmake)
 include(cmake/simd.cmake)
 
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)

--- a/cmake/msvc.cmake
+++ b/cmake/msvc.cmake
@@ -1,0 +1,7 @@
+option(ACQUIRE_MSVC_USE_MD "When ON, prefer linking to the Multhreaded DLL Microsoft C Runtime library (use /MD)")
+
+if(ACQUIRE_MSVC_USE_MD)
+    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")
+else()
+    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 if(NOT TARGET acquire-device-kit)
-    add_subdirectory(acquire-core-libs)
+        add_subdirectory(acquire-core-libs)
 endif()
 
 add_subdirectory(simcams)
@@ -16,9 +16,6 @@ target_link_libraries(${tgt} PRIVATE
         acquire-device-kit
         simcams
         storage
-)
-set_target_properties(${tgt} PROPERTIES
-        MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>"
 )
 
 install(TARGETS ${tgt} LIBRARY DESTINATION lib)

--- a/src/simcams/3rdParty/pcg-c-basic-0.9/CMakeLists.txt
+++ b/src/simcams/3rdParty/pcg-c-basic-0.9/CMakeLists.txt
@@ -1,16 +1,13 @@
-#set(tgt acquire-simulated-camera)
-#target_sources(${tgt} PRIVATE
-#        pcg_basic.h
-#        pcg_basic.c
-#        )
-#target_include_directories(${tgt} PRIVATE ${CMAKE_CURRENT_LIST_DIR})
+# set(tgt acquire-simulated-camera)
+# target_sources(${tgt} PRIVATE
+# pcg_basic.h
+# pcg_basic.c
+# )
+# target_include_directories(${tgt} PRIVATE ${CMAKE_CURRENT_LIST_DIR})
 
 set(tgt pcg)
 add_library(${tgt} OBJECT
         pcg_basic.h
         pcg_basic.c
-        )
+)
 target_include_directories(${tgt} PUBLIC ${CMAKE_CURRENT_LIST_DIR})
-set_target_properties(${tgt} PROPERTIES
-        MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>"
-        )

--- a/src/simcams/CMakeLists.txt
+++ b/src/simcams/CMakeLists.txt
@@ -5,14 +5,11 @@ add_library(${tgt} STATIC
         simulated.camera.h
         simulated.camera.c
         popcount.cpp
-        )
+)
 target_enable_simd(${tgt})
 target_link_libraries(${tgt} PUBLIC
         acquire-core-logger
         acquire-core-platform
         acquire-device-kit
         pcg
-        )
-set_target_properties(${tgt} PROPERTIES
-        MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>"
-        )
+)

--- a/src/storage/CMakeLists.txt
+++ b/src/storage/CMakeLists.txt
@@ -6,18 +6,12 @@ add_library(${tgt} STATIC
         side-by-side-tiff.cpp
         tiff.cpp
         trash.c
-        )
+)
 target_enable_simd(${tgt})
 target_link_libraries(${tgt} PUBLIC pcg)
-set_target_properties(${tgt} PROPERTIES
-        MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>"
-        )
 target_enable_simd(${tgt})
 target_link_libraries(${tgt} PRIVATE
         acquire-core-platform
         acquire-core-logger
         acquire-device-kit
-        )
-set_target_properties(${tgt} PROPERTIES
-        MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>"
-        )
+)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,7 +1,6 @@
 if(${NOTEST})
     message(STATUS "Skipping test targets")
 else()
-
     #
     # PARAMETERS
     #
@@ -22,9 +21,6 @@ else()
         set(tgt ${project}-${name})
         add_executable(${tgt} ${name}.cpp)
         target_compile_definitions(${tgt} PUBLIC "TEST=\"${tgt}\"")
-        set_target_properties(${tgt} PROPERTIES
-            MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>"
-        )
         target_include_directories(${tgt} PRIVATE "../src/simcams")
         target_link_libraries(${tgt}
             acquire-core-platform


### PR DESCRIPTION
see acquire-project/acquire-core-libs#14 and acquire-project/acquire-video-runtime#35

This needs to get updated because it's used in the tests for acquire-video-runtime.