### PR TITLE
Misc tests and CI fixes

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,10 +1,7 @@
-name: Tests
+name: Test and merge
 
 on:
-  push:
-    branches:
-      - main
-  pull_request:
+  pull_request_target:
     branches:
       - main
 
@@ -15,6 +12,7 @@ jobs:
   test:
     name: ${{ matrix.platform }}
     runs-on: ${{ matrix.platform }}
+    if: ${{ github.actor == 'dependabot[bot]' }}
     timeout-minutes: 10
     strategy:
       fail-fast: false
@@ -31,7 +29,8 @@ jobs:
 
       - uses: actions/checkout@v3
         with:
-          submodules: true
+          submodules: recursive
+          ref: "refs/pull/${{ github.event.number }}/merge"
 
       - name: Install Cmake 3.23
         if: ${{ matrix.platform == 'ubuntu-latest' }}
@@ -50,4 +49,30 @@ jobs:
 
       - name: Test
         working-directory: ${{github.workspace}}/build
-        run: ctest -C ${{env.BUILD_TYPE}} -L driver-common --output-on-failure
+        run: ctest -C ${{env.BUILD_TYPE}} -L anyplatform --output-on-failure
+
+  auto-merge:
+    name: "Auto-merge Dependabot PRs"
+    needs: test
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - name: "Get Dependabot metadata"
+        id: dependabot-metadata
+        uses: dependabot/fetch-metadata@v1.1.1
+        with:
+          github-token: ${{ github.token }}
+
+      - name: "Approve the PR"
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.PAT }}
+
+      # Don't auto-merge major version updates
+      - name: "Auto-merge the PR"
+        if: ${{ steps.dependabot-metadata.outputs.update-type != 'version-update:semver-major' }}
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.PAT }}

--- a/.github/workflows/test_pr.yml
+++ b/.github/workflows/test_pr.yml
@@ -50,4 +50,4 @@ jobs:
 
       - name: Test
         working-directory: ${{github.workspace}}/build
-        run: ctest -C ${{env.BUILD_TYPE}} -L driver-common --output-on-failure
+        run: ctest -C ${{env.BUILD_TYPE}} -L acquire-driver-common --output-on-failure

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -30,7 +30,7 @@ else()
             acquire-device-properties
         )
         add_test(NAME test-${tgt} COMMAND ${tgt})
-        set_tests_properties(test-${tgt} PROPERTIES LABELS anyplatform)
+        set_tests_properties(test-${tgt} PROPERTIES LABELS "anyplatform;driver-common")
     endforeach()
 
     #

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -30,7 +30,7 @@ else()
             acquire-device-properties
         )
         add_test(NAME test-${tgt} COMMAND ${tgt})
-        set_tests_properties(test-${tgt} PROPERTIES LABELS "anyplatform;driver-common")
+        set_tests_properties(test-${tgt} PROPERTIES LABELS "anyplatform;acquire-driver-common")
     endforeach()
 
     #


### PR DESCRIPTION
- Fixes an error in the Dependabot automerge job where tests would be run against the main branch rather than the ref branch.
- Provides a `driver-common` ctest label
- Runs `driver-common` labeled tests in CI. This may or may not be the right choice, depending on where we want responsibility for ensuring passing core-libs tests to lie.