### PR TITLE
fix git versioning

### DIFF
--- a/cmake/git-versioning.cmake
+++ b/cmake/git-versioning.cmake
@@ -23,8 +23,13 @@ if(GIT)
     endif()
 endif()
 
-# Output
-add_definitions(-DGIT_TAG=${GIT_TAG})
-add_definitions(-DGIT_HASH=${GIT_HASH})
 set(CPACK_PACKAGE_VERSION ${GIT_TAG})
-message(STATUS "Version ${GIT_TAG} ${GIT_HASH}")
+
+# Adds GIT_TAG and GIT_HASH compiler definitions for target
+function(target_add_git_versioning tgt)
+    message(STATUS "${tgt} Version ${GIT_TAG} ${GIT_HASH}")
+    target_compile_definitions(${tgt} PRIVATE
+        -DGIT_TAG=${GIT_TAG}
+        -DGIT_HASH=${GIT_HASH}
+    )
+endfunction()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,5 +17,6 @@ target_link_libraries(${tgt} PRIVATE
         simcams
         storage
 )
+target_add_git_versioning(${tgt})
 
 install(TARGETS ${tgt} LIBRARY DESTINATION lib)


### PR DESCRIPTION
Gets rid of GIT_TAG and GIT_HASH redefined errors.

Also changes some of the text output on config so we can see what versions of things are being targeted. e.g.:

```
[build] -- acquire-video-runtime Version v0.1.2 773a6f5
[build] -- acquire-driver-common Version v0.1.5 7e94346
```